### PR TITLE
DockerfileのUbuntuイメージとtippecanoeの更新

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
+# FROM ghcr.io/osgeo/gdal:ubuntu-full-3.11.3
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV TIPPECANOE_VERSION=2.66.0
+ENV TIPPECANOE_VERSION=2.78.0
 
 # 必要パッケージのインストール
 RUN apt-get update && apt-get install -y \
@@ -26,7 +27,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl -L https://github.com/felt/tippecanoe/archive/refs/tags/${TIPPECANOE_VERSION}.tar.gz -o tippecanoe.tar.gz && \
     tar -xzf tippecanoe.tar.gz && \
     cd tippecanoe-${TIPPECANOE_VERSION} && \
-    make -j && \
+    make -j$(nproc) && \
     make install && \
     cd .. && rm -rf tippecanoe*
 


### PR DESCRIPTION
@naogify (@shiwaku)
表記件について、以下の対応を行いましたので、お手すきの際に確認をお願いします。🙇

## 対応内容
* DockerfileのUbuntuイメージを `22.04` から `24.04` に更新
  * (補足) こちらの対応により、ogr2ogrのバージョンが `3.4.1` から `3.8.4` となりますが、GeoParquetを読み込めるようにするなど、さらに新しいバージョンへの対応が必要な場合は、1つ下でコメントアウトしている `FROM ghcr.io/osgeo/gdal:ubuntu-full-3.11.3` の方を有効にします。(※ただし、Dockerイメージサイズは約1.2GBから約2.65GBへと、かなり増大する形になります。)
* Dockerfileのtippecanoeバージョンを `2.66.0` から最新の `2.78.0` に更新
* tippecanoeの並列ビルド時に `$(nproc)` を利用するよう修正