### PR TITLE
kata.ymlでグループ化したタイルの出力を可能とする

### DIFF
--- a/scripts/build_tile.sh
+++ b/scripts/build_tile.sh
@@ -15,38 +15,37 @@ echo "MAX_JOBS: $MAX_JOBS"
 # Read defaults from config
 default_cpg=$(yq e '.default.cpg // "UTF-8"' "$CONFIG_FILE")
 default_prj=$(yq e '.default.prj // "EPSG:4326"' "$CONFIG_FILE")
-merge_minzoom=$(yq e '.default.minzoom // 8' "$CONFIG_FILE")
-merge_maxzoom=$(yq e '.default.maxzoom // 14' "$CONFIG_FILE")
 
-# Gather layer names
-mapfile -t source_layers < <(yq e 'keys | .[]' "$CONFIG_FILE" | grep -v '^default$')
+# Gather tile names
+mapfile -t target_tiles < <(yq e 'keys | .[]' "$CONFIG_FILE" | grep -v '^default$')
 
 # 全体処理開始
 start_time_all=$(date +%s)
 
-generate_layer() {
-  local source_layer=$1
-  echo "==== Source Layer: $source_layer ===="
+generate_tile_layer() {
+  local target_tile=$1
+  local source_layer=$2
+  echo "==== Target Tile: $target_tile, Source Layer: $source_layer ===="
 
-  local mbtiles_file="${OUTPUT_DIR}/${source_layer}.mbtiles"
+  local mbtiles_file="${OUTPUT_DIR}/${target_tile}/${source_layer}.mbtiles"
   if [[ -f "$mbtiles_file" ]]; then
     echo "MBTiles exists, skip: $mbtiles_file"
     return
   fi
 
   # Read layer-specific parameters
-  local minzoom=$(yq e ".\"$source_layer\".minzoom" "$CONFIG_FILE")
-  local maxzoom=$(yq e ".\"$source_layer\".maxzoom" "$CONFIG_FILE")
-  local sources_length=$(yq e ".\"$source_layer\".source | length" "$CONFIG_FILE")
+  local minzoom=$(yq e ".\"$target_tile\".\"$source_layer\".minzoom" "$CONFIG_FILE")
+  local maxzoom=$(yq e ".\"$target_tile\".\"$source_layer\".maxzoom" "$CONFIG_FILE")
+  local sources_length=$(yq e ".\"$target_tile\".\"$source_layer\".source | length" "$CONFIG_FILE")
   local tmp_ndjson_list=()
 
   # Start timer for ogr2ogr → tippecanoe
   local start_time_layer=$(date +%s)
 
   for i in $(seq 0 $((sources_length - 1))); do
-    local source=$(yq e ".\"$source_layer\".source[$i]" "$CONFIG_FILE")
+    local source=$(yq e ".\"$target_tile\".\"$source_layer\".source[$i]" "$CONFIG_FILE")
     local base=$(basename "$source" .shp)
-    local tmp_ndjson="${TMPDIR}/${source_layer}_${i}_${base}.ndjson"
+    local tmp_ndjson="${TMPDIR}/${target_tile}_${source_layer}_${i}_${base}.ndjson"
     echo "  Source: $source → $tmp_ndjson"
 
     ogr2ogr -f GeoJSONSeq \
@@ -82,38 +81,54 @@ generate_layer() {
   rm -f "${tmp_ndjson_list[@]}"
 }
 
-# Parallel generation of each layer
-for source_layer in "${source_layers[@]}"; do
-  generate_layer "$source_layer" &
+# Parallel generation of each tile/layer
+for target_tile in "${target_tiles[@]}"; do
+  mkdir -p "$OUTPUT_DIR/$target_tile"
+  mapfile -t source_layers < <(yq e ".\"$target_tile\" | keys | .[]" "$CONFIG_FILE")
+  for source_layer in "${source_layers[@]}"; do
+    generate_tile_layer "$target_tile" "$source_layer" &
+    if [[ $(jobs -r -p | wc -l) -ge $MAX_JOBS ]]; then
+      wait -n
+    fi
+  done
+done
+wait
+
+merge_tile_layers() {
+  local target_tile=$1
+  # Merge key tiles
+  echo "=== Merging $target_tile mbtiles ==="
+  start_time_merge=$(date +%s)
+
+  tile-join \
+    -o "${OUTPUT_DIR}/$target_tile.mbtiles" \
+    --overzoom --no-tile-size-limit \
+    --force \
+    $(find "$OUTPUT_DIR" -name "*.mbtiles" ! -name "$target_tile.mbtiles")
+
+  # Stop merge timer and report
+  end_time_merge=$(date +%s)
+  elapsed_merge=$((end_time_merge - start_time_merge))
+  echo "  → Merge time: $((elapsed_merge/60))m $((elapsed_merge%60))s"
+
+  # Report merged file size
+  merged_size=$(du -h "${OUTPUT_DIR}/$target_tile.mbtiles" | cut -f1)
+  echo "  → Size of merged file: $merged_size"
+}
+
+# Parallel merging each tile/layers
+for target_tile in "${target_tiles[@]}"; do
+  merge_tile_layers "$target_tile" &
   if [[ $(jobs -r -p | wc -l) -ge $MAX_JOBS ]]; then
     wait -n
   fi
 done
 wait
 
-# Merge all tiles
-echo "=== Merging all.mbtiles ==="
-start_time_merge=$(date +%s)
-
-tile-join \
-  -o "${OUTPUT_DIR}/all.mbtiles" \
-  --overzoom --no-tile-size-limit \
-  -Z "$merge_minzoom" -z "$merge_maxzoom" --force \
-  $(find "$OUTPUT_DIR" -name "*.mbtiles" ! -name "all.mbtiles")
-
-# Stop merge timer and report
-end_time_merge=$(date +%s)
-elapsed_merge=$((end_time_merge - start_time_merge))
-echo "  → Merge time: $((elapsed_merge/60))m $((elapsed_merge%60))s"
-
-# Report merged file size
-merged_size=$(du -h "${OUTPUT_DIR}/all.mbtiles" | cut -f1)
-echo "  → Size of merged file: $merged_size"
-
 # 全体処理終了／時間報告
 end_time_all=$(date +%s)
 elapsed_all=$((end_time_all - start_time_all))
-echo "All tiles generated and merged at ${OUTPUT_DIR}/all.mbtiles"
+echo "All tiles generated and merged at ${OUTPUT_DIR}/*.mbtiles"
 echo "===> Total time: $((elapsed_all/60))m $((elapsed_all%60))s"
 
 # Cleanup temporary files

--- a/scripts/build_tile.sh
+++ b/scripts/build_tile.sh
@@ -104,7 +104,7 @@ merge_tile_layers() {
     -o "${OUTPUT_DIR}/$target_tile.mbtiles" \
     --overzoom --no-tile-size-limit \
     --force \
-    $(find "$OUTPUT_DIR" -name "*.mbtiles" ! -name "$target_tile.mbtiles")
+    $(find "$OUTPUT_DIR/$target_tile/" -name "*.mbtiles")
 
   # Stop merge timer and report
   end_time_merge=$(date +%s)


### PR DESCRIPTION
@naogify (CC: @shiwaku)
まだ実データを用いたデータ変換の検証が必要になると思いますが、 #7 に関連して以下の対応を行いましたので、お手すきの際に確認をお願いいたします。

## 対応内容

- グローバルの `minzoom`, `maxzoom` を削除
  - ※各ソースレイヤのタイルをまとめる際も、 `tile-join` が自動的に設定してくれるため、タイルキー側にも設定していません
- `generate_layer()` を `generate_tile_layer()` に変更し、第1引数に出力タイル(`target_tile`)を受け付け、以下の変更に対応:
  - ソースレイヤのタイル出力先に `${target_tile}` フォルダを追加 (マージ時の処理を簡略化するため)
  - 各YAMLプロパティの読み込み先に `.\"$target_tile\"` を追加
  - 念のため、TMPファイル出力先ファイル名に `${target_tile}_` を追加
  - 並列でのソースレイヤ処理時にタイルキーを取得するループ層を追加
- `merge_tile_layers()` 関数を追加し、上記のソースレイヤ変換処理後に、タイルキー毎にマージする処理を追加

---

Closes #7